### PR TITLE
[ARQ-448] Added admin login credentials for GlassFish Remote 3.1

### DIFF
--- a/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishRestConfiguration.java
+++ b/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishRestConfiguration.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 /**
  *
  * @author <a href="http://community.jboss.org/people/LightGuard">Jason Porter</a>
@@ -25,96 +24,118 @@ import org.jboss.arquillian.spi.ConfigurationException;
 import org.jboss.arquillian.spi.ContainerProfile;
 import org.jboss.arquillian.spi.client.container.ContainerConfiguration;
 
-public class GlassFishRestConfiguration implements ContainerConfiguration
-{
-   /**
-    * Glassfish Admin Console port.
-    * Used to build the URL for the REST request.
-    */
-   private int remoteServerAdminPort = 4848;
+public class GlassFishRestConfiguration implements ContainerConfiguration {
 
-   /**
-    * Glassfish address.
-    * Used to build the URL for the REST request.
-    */
-   private String remoteServerAddress = "localhost";
+    /**
+     * Glassfish Admin Console port.
+     * Used to build the URL for the REST request.
+     */
+    private int remoteServerAdminPort = 4848;
+    /**
+     * Glassfish address.
+     * Used to build the URL for the REST request.
+     */
+    private String remoteServerAddress = "localhost";
+    /**
+     * Flag indicating the administration url uses a secure connection.
+     * Used to build the URL for the REST request.
+     */
+    private boolean remoteServerAdminHttps = false;
+    /**
+     * Flag indicating application urls use secure connections.
+     * Used to build the URL for the REST request.
+     */
+    private boolean remoteServerHttps = false;
+    /**
+     * Http port for application urls.
+     * Used to build the URL for the REST request.
+     */
+    private int remoteServerHttpPort = 8080;
+    /**
+     * Flag indicating the remote server requires an admin user and password. 
+     */
+    private boolean remoteServerAuthorisation = false;
+    /**
+     * Authorised admin user in the remote glassfish admin realm
+     */
+    private String remoteServerAdminUser;
+    /**
+     * Authorised admin user password
+     */
+    private String remoteServerAdminPassword;
 
-   /**
-    * Flag indicating the administration url uses a secure connection.
-    * Used to build the URL for the REST request.
-    */
-   private boolean remoteServerAdminHttps = false;
+    /**
+     * Type of container this is.
+     * @return CLIENT
+     */
+    public ContainerProfile getContainerProfile() {
+        return ContainerProfile.CLIENT;
+    }
 
-   /**
-    * Flag indicating application urls use secure connections.
-    * Used to build the URL for the REST request.
-    */
-   private boolean remoteServerHttps = false;
+    public String getRemoteServerAddress() {
+        return remoteServerAddress;
+    }
 
-   /**
-    * Http port for application urls.
-    * Used to build the URL for the REST request.
-    */
-   private int remoteServerHttpPort = 8080;
+    public void setRemoteServerAddress(String remoteServerAddress) {
+        this.remoteServerAddress = remoteServerAddress;
+    }
 
-   /**
-    * Type of container this is.
-    * @return CLIENT
-    */
-   public ContainerProfile getContainerProfile()
-   {
-      return ContainerProfile.CLIENT;
-   }
+    public int getRemoteServerAdminPort() {
+        return remoteServerAdminPort;
+    }
 
-   public String getRemoteServerAddress()
-   {
-      return remoteServerAddress;
-   }
+    public void setRemoteServerAdminPort(int remoteServerAdminPort) {
+        this.remoteServerAdminPort = remoteServerAdminPort;
+    }
 
-   public void setRemoteServerAddress(String remoteServerAddress)
-   {
-      this.remoteServerAddress = remoteServerAddress;
-   }
+    public boolean isRemoteServerAdminHttps() {
+        return remoteServerAdminHttps;
+    }
 
-   public int getRemoteServerAdminPort()
-   {
-      return remoteServerAdminPort;
-   }
+    public void setRemoteServerAdminHttps(boolean remoteServerAdminHttps) {
+        this.remoteServerAdminHttps = remoteServerAdminHttps;
+    }
 
-   public void setRemoteServerAdminPort(int remoteServerAdminPort)
-   {
-      this.remoteServerAdminPort = remoteServerAdminPort;
-   }
+    public int getRemoteServerHttpPort() {
+        return remoteServerHttpPort;
+    }
 
-   public boolean isRemoteServerAdminHttps()
-   {
-      return remoteServerAdminHttps;
-   }
+    public void setRemoteServerHttpPort(int remoteServerHttpPort) {
+        this.remoteServerHttpPort = remoteServerHttpPort;
+    }
 
-   public void setRemoteServerAdminHttps(boolean remoteServerAdminHttps)
-   {
-      this.remoteServerAdminHttps = remoteServerAdminHttps;
-   }
+    public boolean isRemoteServerHttps() {
+        return remoteServerHttps;
+    }
 
-   public int getRemoteServerHttpPort()
-   {
-      return remoteServerHttpPort;
-   }
+    public void setRemoteServerHttps(boolean remoteServerHttps) {
+        this.remoteServerHttps = remoteServerHttps;
+    }
 
-   public void setRemoteServerHttpPort(int remoteServerHttpPort)
-   {
-      this.remoteServerHttpPort = remoteServerHttpPort;
-   }
+    public boolean isRemoteServerAuthorisation() {
+        return remoteServerAuthorisation;
+    }
 
-   public boolean isRemoteServerHttps()
-   {
-      return remoteServerHttps;
-   }
+    public void setRemoteServerAuthorisation(boolean remoteServerAuthorisation) {
+        this.remoteServerAuthorisation = remoteServerAuthorisation;
+    }
 
-   public void setRemoteServerHttps(boolean remoteServerHttps)
-   {
-      this.remoteServerHttps = remoteServerHttps;
-   }
+    public String getRemoteServerAdminUser() {
+        return remoteServerAdminUser;
+    }
+
+    public void setRemoteServerAdminUser(String remoteServerAdminUser) {
+        this.setRemoteServerAuthorisation(true);
+        this.remoteServerAdminUser = remoteServerAdminUser;
+    }
+
+    public String getRemoteServerAdminPassword() {
+        return remoteServerAdminPassword;
+    }
+
+    public void setRemoteServerAdminPassword(String remoteServerAdminPassword) {
+        this.remoteServerAdminPassword = remoteServerAdminPassword;
+    }
 
     /**
      * Validates if current configuration is valid, that is if all required

--- a/glassfish-remote-3.1/src/test/resources/arquillian.xml
+++ b/glassfish-remote-3.1/src/test/resources/arquillian.xml
@@ -25,4 +25,16 @@
       <deploymentExportPath>target/test-archives</deploymentExportPath>
    </engine>
    -->
+   
+    <container qualifier="glassfish" default="true">
+        <configuration>
+            <property name="remoteServerAddress">localhost</property>
+            <property name="remoteServerHttpPort">8080</property>
+            <property name="remoteServerAdminPort">4848</property> 
+            <property name="remoteServerAdminUser">admin</property> 
+            <property name="remoteServerAdminPassword">password</property> 
+        </configuration>
+    </container>
+    
+    
 </arquillian>


### PR DESCRIPTION
Added two parameters to arquillian.xml 
remoteServerAdminUser and remoteServerAdminPassword to allow a user to pass through a username and password corresponding with an admin user that has previously been defined in the GlassFish admin-realm.
If a value for the remote admin user has been set in arquillian.xml then now adds an HTTPBasicAuthFilter filter to the jersey client with the given credentials.
