### PR TITLE
ARQ-627 Replace the nodeHost value in response, with adminHost conditionally

### DIFF
--- a/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
+++ b/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
@@ -406,6 +406,7 @@ public class GlassFishClientService implements GlassFishClient {
         }
         return nodeHost;
 	}
+	
 	/**
 	 * Get the http/https port number of the Admin Server
 	 * 


### PR DESCRIPTION
If the response from a remote DAS contains localhost, then the adminHost value is used to connect to the Glassfish instance. This prevents Arquillian from attempting to connect to localhost, which is invalid for Arquillian, as it really is localhost for DAS.
