### PR TITLE
ARQ-643 Removed the serverHttps property from Arquilian config for GF.

### DIFF
--- a/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishRestConfiguration.java
+++ b/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishRestConfiguration.java
@@ -46,12 +46,6 @@ public class GlassFishRestConfiguration implements ContainerConfiguration
 	private boolean adminHttps = false;
 	
 	/**
-	 * Flag indicating application urls use secure connections.
-	 * Used to build the URL for the REST request.
-	 */
-	private boolean serverHttps = false;
-	
-	/**
 	 * @deprecated
 	 * Http port for application urls.
 	 * Used to build the URL for the REST request.
@@ -176,11 +170,6 @@ public class GlassFishRestConfiguration implements ContainerConfiguration
 		this.adminHttps = adminHttps;
 	}
 	
-	public boolean isServerHttps()
-	{
-		return serverHttps;
-	}
-	
 	/**
 	 * @deprecated
 	 */
@@ -194,19 +183,6 @@ public class GlassFishRestConfiguration implements ContainerConfiguration
     public void setRemoteServerHttpPort(int remoteServerHttpPort) {
     	this.remoteServerHttpPort = remoteServerHttpPort;
     }
-	
-	/**
-	 * @deprecated
-	 */
-	public void setRemoteServerHttps(Boolean serverHttps)
-	{
-		this.serverHttps = serverHttps;
-	}
-	
-	public void setServerHttps(boolean serverHttps)
-	{
-		this.serverHttps = serverHttps;
-	}	
 	
     public boolean isAuthorisation() {
         return authorisation;

--- a/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
+++ b/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
@@ -214,7 +214,7 @@ public class GlassFishClientService implements GlassFishClient {
 		Map<String, String> subComponents = (Map<String, String>) subComponentsResponce.get("properties");
 		
         // Build up the HTTPContext object using the nodeAddress information
-        int port = ( !this.configuration.isServerHttps() ) ? nodeAddress.getHttpPort() : nodeAddress.getHttpsPort();
+        int port = nodeAddress.getHttpPort();
         HTTPContext httpContext = new HTTPContext( nodeAddress.getHost(), port );
 		
         // Add the servlets to the HTTPContext


### PR DESCRIPTION
The serverHttps property has been removed from GlassFishRestConfiguration. The related deprecated property remoteServerHttps was also removed. The NodeAddress class continues to store a HTTPS port, so that this property may be re-introduced in a later version, without a lot of trouble.
