### PR TITLE
ARQ-658 Corrected the logic to obtain the context root for a deployment.

### DIFF
--- a/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
+++ b/glassfish-remote-3.1/src/main/java/org/jboss/arquillian/container/glassfish/remote_3_1/clientutils/GlassFishClientService.java
@@ -305,8 +305,13 @@ public class GlassFishClientService implements GlassFishClient {
 			if ( moduleProperties != null && !moduleProperties.isEmpty() ) {
 				String moduleInfo = moduleProperties.get("moduleInfo");
 				if (moduleInfo.startsWith(componentName)) {
-					// Get the webmodul's contextRoot 
-					contextRoot = moduleInfo.substring( moduleInfo.indexOf("/") );
+					// Get the webmodule's contextRoot 
+					// The moduleInfo property has the format - moduleArchiveURI:moduleType:contextRoot
+					// The contextRoot is extracted, and removed of any prefixed slash.
+					String[] moduleInfoElements = moduleInfo.split(":");
+					contextRoot = moduleInfoElements[2];
+					contextRoot = contextRoot.indexOf("/") > -1 ? contextRoot.substring(contextRoot.indexOf("/"))
+							: contextRoot;
 				}
 			} else {
 				throw new GlassFishClientException("Cuold not resolve the web-module contextRoot");

--- a/glassfish-remote-3.1/src/test/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishDeployWithoutAppXmlTest.java
+++ b/glassfish-remote-3.1/src/test/java/org/jboss/arquillian/container/glassfish/remote_3_1/GlassFishDeployWithoutAppXmlTest.java
@@ -1,0 +1,42 @@
+package org.jboss.arquillian.container.glassfish.remote_3_1;
+
+import static org.junit.Assert.assertNotNull;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class GlassFishDeployWithoutAppXmlTest
+{
+   @Inject
+   private Client client;
+   
+   @Deployment
+   public static EnterpriseArchive createTestArchive()
+   {
+      JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar").addClasses(Client.class,GlassFishDeployWithoutAppXmlTest.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, ArchivePaths.create("beans.xml"));
+      EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(jar);
+      return ear;
+   }
+   
+   @Test
+   public void testClient()
+   {
+      assertNotNull(client);
+   }
+}
+
+class Client
+{
+   
+}


### PR DESCRIPTION
The GlassFish extension now parses the moduleInfo property assuming that it contains the contextRoot in the format - `moduleArchiveURI:moduleType:contextRoot`. This is of course, done only for servlet sub-components.

Added a testcase that does not generate a deployment with an `application.xml` file. Not having this file, tends to get GlassFish to register the contextRoot for the module, without a slash.
