### PR TITLE
Bump arquillian_core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <!-- Properties -->
     <properties>
 
-        <version.arquillian_core>1.0.0.CR7</version.arquillian_core>
+        <version.arquillian_core>1.0.0.Final</version.arquillian_core>
         <version.jersey>1.10</version.jersey>
         <version.jboss.javaee-6_api>1.0.0.Final</version.jboss.javaee-6_api>
 


### PR DESCRIPTION
While using arquillian-glassfish-embedded-3.1:1.0.0.CR3 I got NoSuchMethodError while trying to use @ArquillianResource

Stack:

```
java.lang.NoSuchMethodError: org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData.getContexts(Ljava/lang/Class;)Ljava/util/Collection;
```

From what I could find out debugging some old CR7 ended dragged into classpath causing the problem.

Bumping version makes all good, I was hopping for a new arquillian-glassfish-embedded-3.1 release with this punctual fix.

This problem also affect arquillian 1.0.1
