### PR TITLE
Allow executing asadmin commands post-start and pre-stop

### DIFF
--- a/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedContainerConfiguration.java
+++ b/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedContainerConfiguration.java
@@ -42,6 +42,12 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
 
     private boolean allowConnectingToRunningServer = false;
 
+    private String commandFileDelimiter = "\\s";
+
+    private String postStartCommandFile = null;
+
+    private String preStopCommandFile = null;
+
     public String getGlassFishHome() {
         return glassFishHome;
     }
@@ -99,6 +105,39 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
      */
     public void setAllowConnectingToRunningServer(boolean allowConnectingToRunningServer) {
         this.allowConnectingToRunningServer = allowConnectingToRunningServer;
+    }
+
+    public String getCommandFileDelimiter() {
+        return commandFileDelimiter;
+    }
+
+    /**
+     * @param commandFileDelimiter The delimiter to use for separating tokens in postStartCommandFile and preStopCommandFile
+     */
+    public void setCommandFileDelimiter(final String commandFileDelimiter) {
+        this.commandFileDelimiter = commandFileDelimiter;
+    }
+
+    public String getPostStartCommandFile() {
+        return postStartCommandFile;
+    }
+
+    /**
+     * @param postStartCommandFile A file of asadmin command to run after starting Glassfish.
+     */
+    public void setPostStartCommandFile(final String postStartCommandFile) {
+        this.postStartCommandFile = postStartCommandFile;
+    }
+
+    public String getPreStopCommandFile() {
+        return preStopCommandFile;
+    }
+
+    /**
+     * @param preStopCommandFile A file of asadmin command to run before shutting down Glassfish.
+     */
+    public void setPreStopCommandFile(final String preStopCommandFile) {
+        this.preStopCommandFile = preStopCommandFile;
     }
 
     @Override

--- a/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishServerControl.java
+++ b/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishServerControl.java
@@ -78,11 +78,12 @@ public class GlassFishServerControl {
         if (config.getDomain() != null) {
             args.add(config.getDomain());
         }
+        args.add("-t");
         
         return executeAdminCommand(description, admincmd, args);
     }
-    
-    private int executeAdminCommand(String description, String admincmd, List<String> args) {
+
+    public int executeAdminCommand(String description, String admincmd, List<String> args) {
         List<String> cmd = new ArrayList<String>();
         cmd.add("java");
 
@@ -91,8 +92,6 @@ public class GlassFishServerControl {
         
         cmd.add(admincmd);
         cmd.addAll(args);
-        
-        cmd.add("-t");
         
         if (config.isOutputToConsole()) {
             System.out.println(description + " using command: " + cmd.toString());


### PR DESCRIPTION
AFAIK This is the only way to create jdbc-connection-pool's and datasources. I tried adding a glassfish-web.xml to my deployment but it doesn't seem to work with arquillian managed. This PR allows reading scripts of these commands after the server starts and before it stops. The scripts are tokenized using a customizable delimiter that defaults to \s.