### PR TITLE
Added option for ignoring certificate check when accessing the rest interface of remote glassfish using https

### DIFF
--- a/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishConfiguration.java
+++ b/glassfish-common/src/main/java/org/jboss/arquillian/container/glassfish/CommonGlassFishConfiguration.java
@@ -50,6 +50,8 @@ public class CommonGlassFishConfiguration implements ContainerConfiguration
    
    private String type = null;
 
+   private boolean ignoreCertificate = false;
+
    public CommonGlassFishConfiguration()
    {
       super();
@@ -228,4 +230,16 @@ public class CommonGlassFishConfiguration implements ContainerConfiguration
     	}
     }
 
+   public boolean isIgnoreCertificate() {
+      return ignoreCertificate;
+   }
+
+   /**
+    *
+    * @param ignoreCertificate Flag indicating that certificate of the remote server
+    *                                (when using https) should be ignored
+    */
+   public void setIgnoreCertificate(boolean ignoreCertificate) {
+      this.ignoreCertificate = ignoreCertificate;
+   }
 }

--- a/glassfish-remote-3.1/src/test/resources/example_arquillian.xml
+++ b/glassfish-remote-3.1/src/test/resources/example_arquillian.xml
@@ -18,6 +18,7 @@
                 <property name="adminUser">admin</property>
                 <property name="adminPassword">yourPassword</property>
                 <property name="target">server</property>
+                <property name="ignoreCertificate">false</property>
 	       </configuration>
 	   </container>
     </group>


### PR DESCRIPTION
I had problem with self-signed certificate when runnign test against remote-container which is provided by Docker-container. Added parameter to configuration which disables certificate check.

Example of the set up is in https://github.com/reap/test-arquillian-with-docker-container
