### PR TITLE
Initial support for adding bindHttpsPort configuration property in Embedded Glassfish

### DIFF
--- a/glassfish-embedded-3.1/src/main/java/org/jboss/arquillian/container/glassfish/embedded_3_1/GlassFishConfiguration.java
+++ b/glassfish-embedded-3.1/src/main/java/org/jboss/arquillian/container/glassfish/embedded_3_1/GlassFishConfiguration.java
@@ -37,6 +37,7 @@ import java.util.logging.Logger;
  */
 public class GlassFishConfiguration implements ContainerConfiguration {
     private int bindHttpPort = 8181;
+    private int bindHttpsPort = 8182;
     private String instanceRoot = null;
     private String installRoot = null;
     private boolean configurationReadOnly = true;
@@ -60,6 +61,17 @@ public class GlassFishConfiguration implements ContainerConfiguration {
      */
     public void setBindHttpPort(int bindHttpPort) {
         this.bindHttpPort = bindHttpPort;
+    }
+
+    public int getBindHttpsPort() {
+      return bindHttpsPort;
+    }
+
+    /**
+     * @param bindHttpsPort The port number of the https-listener for the embedded GlassFish server.
+     */
+    public void setBindHttpsPort(int bindHttpsPort) {
+        this.bindHttpsPort = bindHttpsPort;
     }
 
     public String getInstanceRoot() {

--- a/glassfish-embedded-3.1/src/main/java/org/jboss/arquillian/container/glassfish/embedded_3_1/GlassFishContainer.java
+++ b/glassfish-embedded-3.1/src/main/java/org/jboss/arquillian/container/glassfish/embedded_3_1/GlassFishContainer.java
@@ -77,6 +77,7 @@ public class GlassFishContainer implements DeployableContainer<GlassFishConfigur
 
     private boolean shouldSetPort = true;
     private int bindHttpPort;
+    private int bindHttpsPort;
 
     /* (non-Javadoc)
      * @see org.jboss.arquillian.spi.client.container.DeployableContainer#getConfigurationClass()
@@ -126,6 +127,8 @@ public class GlassFishContainer implements DeployableContainer<GlassFishConfigur
         if (shouldSetPort) {
             bindHttpPort = configuration.getBindHttpPort();
             serverProps.setPort("http-listener", bindHttpPort);
+            bindHttpsPort = configuration.getBindHttpsPort();
+            serverProps.setPort("https-listener", bindHttpsPort);
         }
 
         try {

--- a/glassfish-embedded-3.1/src/test/resources/arquillian.xml
+++ b/glassfish-embedded-3.1/src/test/resources/arquillian.xml
@@ -11,6 +11,7 @@
         src/test/resources/glassfish-resources2.xml
       </property>
       <property name="bindHttpPort">7070</property>
+      <property name="bindHttpsPort">7071</property>
     </configuration>
   </container>
 </arquillian>


### PR DESCRIPTION
patch to implement initial bindHttpsPort configuration support for issue #29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-container-glassfish/30)
<!-- Reviewable:end -->
