### PR TITLE
support for starting the derby database

### DIFF
--- a/glassfish-managed-3.1/pom.xml
+++ b/glassfish-managed-3.1/pom.xml
@@ -55,7 +55,7 @@
             <groupId>org.jboss.arquillian.testenricher</groupId>
             <artifactId>arquillian-testenricher-initialcontext</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.spec</groupId>
             <artifactId>jboss-javaee-6.0</artifactId>
@@ -120,7 +120,7 @@
         <profile>
             <id>4.x</id>
             <properties>
-                <version.glassfish>4.0-b72</version.glassfish>
+                <version.glassfish>4.1.1</version.glassfish>
             </properties>
         </profile>
     </profiles>

--- a/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedContainerConfiguration.java
+++ b/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedContainerConfiguration.java
@@ -17,7 +17,6 @@
 package org.jboss.arquillian.container.glassfish.managed_3_1;
 
 import java.io.File;
-
 import org.jboss.arquillian.container.glassfish.CommonGlassFishConfiguration;
 import org.jboss.arquillian.container.glassfish.clientutils.GlassFishClient;
 import org.jboss.arquillian.container.spi.ConfigurationException;
@@ -41,6 +40,8 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
     private boolean debug = false;
 
     private boolean allowConnectingToRunningServer = false;
+
+    private boolean startDerby = false;
 
     public String getGlassFishHome() {
         return glassFishHome;
@@ -99,6 +100,17 @@ public class GlassFishManagedContainerConfiguration extends CommonGlassFishConfi
      */
     public void setAllowConnectingToRunningServer(boolean allowConnectingToRunningServer) {
         this.allowConnectingToRunningServer = allowConnectingToRunningServer;
+    }
+
+    public boolean isStartDerby() {
+        return startDerby;
+    }
+
+    /**
+     * @param startDerby Flag to start/stop the registered derby server using standard Derby port
+     */
+    public void setStartDerby(boolean startDerby) {
+        this.startDerby = startDerby;
     }
 
     @Override

--- a/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishServerControl.java
+++ b/glassfish-managed-3.1/src/main/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishServerControl.java
@@ -22,27 +22,32 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 
 /**
  * A class for issuing asadmin commands using the admin-cli.jar of the GlassFish distribution.
- * 
+ *
  * @author <a href="http://community.jboss.org/people/dan.j.allen">Dan Allen</a>
  */
 public class GlassFishServerControl {
+
     private static final Logger logger = Logger.getLogger(GlassFishServerControl.class.getName());
     private GlassFishManagedContainerConfiguration config;
     private Thread shutdownHook;
-    
+
     public GlassFishServerControl(GlassFishManagedContainerConfiguration config) {
         this.config = config;
     }
-    
+
     public void start() throws LifecycleException {
+        if (config.isStartDerby()) {
+            startDerbyDatabase();
+        }
+
         String admincmd = "start-domain";
         List<String> args = new ArrayList<String>();
         if (config.isDebug()) {
@@ -52,17 +57,20 @@ public class GlassFishServerControl {
         if (result > 0) {
             throw new LifecycleException("Could not start container");
         }
-        
+
         shutdownHook = new Thread(new Runnable() {
 
             @Override
             public void run() {
                 executeAdminDomainCommand("Forcing container shutdown", "stop-domain", new ArrayList<String>());
+                if (config.isStartDerby()) {
+                    executeAdminDomainCommand("Forcing database shutdown", "stop-database", new ArrayList<String>());
+                }
             }
         });
         Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
-    
+
     public void stop() throws LifecycleException {
         if (shutdownHook != null) {
             Runtime.getRuntime().removeShutdownHook(shutdownHook);
@@ -72,28 +80,47 @@ public class GlassFishServerControl {
         if (result > 0) {
             throw new LifecycleException("Could not stop container");
         }
+
+        if (config.isStartDerby()) {
+            stopDerbyDatabase();
+        }
     }
-    
+
+    private void startDerbyDatabase() throws LifecycleException {
+        final int statusCode = executeAdminDomainCommand("Starting database", "start-database", Collections.EMPTY_LIST);
+        if (statusCode > 0) {
+            throw new LifecycleException("Could not start database");
+        }
+    }
+
+    private void stopDerbyDatabase() throws LifecycleException {
+        final int statusCode = executeAdminDomainCommand("Stopping database", "stop-database", Collections.EMPTY_LIST);
+        if (statusCode > 0) {
+            throw new LifecycleException("Could not stop database");
+        }
+    }
+
     private int executeAdminDomainCommand(String description, String admincmd, List<String> args) {
         if (config.getDomain() != null) {
             args.add(config.getDomain());
         }
-        
+
         return executeAdminCommand(description, admincmd, args);
     }
-    
+
     private int executeAdminCommand(String description, String admincmd, List<String> args) {
         List<String> cmd = new ArrayList<String>();
         cmd.add("java");
 
         cmd.add("-jar");
         cmd.add(config.getAdminCliJar().getAbsolutePath());
-        
+
         cmd.add(admincmd);
         cmd.addAll(args);
-        
+
+        // very concise output data in a format that is optimized for use in scripts instead of for reading by humans
         cmd.add("-t");
-        
+
         if (config.isOutputToConsole()) {
             System.out.println(description + " using command: " + cmd.toString());
         }
@@ -111,10 +138,10 @@ public class GlassFishServerControl {
                 logger.log(Level.INFO, description + " interrupted.");
                 return 1;
             }
-         } catch (IOException e) {
-             logger.log(Level.SEVERE, description + " failed.", e);
-             return 1;
-         }
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, description + " failed.", e);
+            return 1;
+        }
     }
 
     private class ConsoleConsumer implements Runnable {

--- a/glassfish-managed-3.1/src/test/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedDeployEarTest.java
+++ b/glassfish-managed-3.1/src/test/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedDeployEarTest.java
@@ -16,16 +16,12 @@
  */
 package org.jboss.arquillian.container.glassfish.managed_3_1;
 
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
-
 import javax.servlet.annotation.WebServlet;
-
+import static org.hamcrest.core.IsEqual.equalTo;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -34,6 +30,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,7 +56,7 @@ public class GlassFishManagedDeployEarTest {
                 .addAsModule(ejb);
         return ear;
     }
-    
+
     @ArquillianResource
     private URL deploymentUrl;
 
@@ -72,6 +69,6 @@ public class GlassFishManagedDeployEarTest {
         BufferedReader in = new BufferedReader(new InputStreamReader(response.getInputStream()));
         final String result = in.readLine();
 
-        assertThat(result, equalTo("Hello"));
+        assertThat(result, equalTo("Hello-0"));
     }
 }

--- a/glassfish-managed-3.1/src/test/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedDeployWarTest.java
+++ b/glassfish-managed-3.1/src/test/java/org/jboss/arquillian/container/glassfish/managed_3_1/GlassFishManagedDeployWarTest.java
@@ -16,22 +16,19 @@
  */
 package org.jboss.arquillian.container.glassfish.managed_3_1;
 
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
-
 import javax.servlet.annotation.WebServlet;
-
+import static org.hamcrest.core.IsEqual.equalTo;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,7 +49,7 @@ public class GlassFishManagedDeployWarTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
-    
+
     @ArquillianResource
     private URL deploymentUrl;
 
@@ -65,7 +62,7 @@ public class GlassFishManagedDeployWarTest {
         BufferedReader in = new BufferedReader(new InputStreamReader(response.getInputStream()));
         final String result = in.readLine();
 
-        assertThat(result, equalTo("Hello"));
+        assertThat(result, equalTo("Hello-0"));
     }
 
 }

--- a/glassfish-managed-3.1/src/test/resources/arquillian.xml
+++ b/glassfish-managed-3.1/src/test/resources/arquillian.xml
@@ -4,23 +4,25 @@
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <!-- Uncomment to have test archives exported to the file system for inspection -->
-    <!-- 
-    <engine> 
-        <property name="deploymentExportPath">target/</property> 
-    </engine> 
+    <!--
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
     -->
 
     <container qualifier="glassfish" default="true">
         <configuration>
-            <property name="glassFishHome">target/glassfish3</property>
+            <property name="glassFishHome">target/glassfish4</property>
             <property name="adminHost">localhost</property>
             <property name="adminPort">4848</property>
+            <property name="startDerby">true</property>
+            <property name="outputToConsole">true</property>
         </configuration>
     </container>
 
     <container qualifier="glassfish-auth">
         <configuration>
-            <property name="glassFishHome">target/glassfish3</property>
+            <property name="glassFishHome">target/glassfish4</property>
             <property name="adminHost">localhost</property>
             <property name="adminPort">4848</property>
             <property name="adminUser">admin</property>

--- a/glassfish-managed-3.1/src/test/resources/arquillian.xml
+++ b/glassfish-managed-3.1/src/test/resources/arquillian.xml
@@ -16,7 +16,6 @@
             <property name="adminHost">localhost</property>
             <property name="adminPort">4848</property>
             <property name="startDerby">true</property>
-            <property name="outputToConsole">true</property>
         </configuration>
     </container>
 


### PR DESCRIPTION
It would be very handy to let the derby database start automatically (on demand) in the managed environment.

I was forced to bump the glassfish version used for testing from 4.0-b72 to 4.1.1. This was due to a bug that refused me to start the derby database failing with this error:

    AccessControlException: access denied ("java.net.SocketPermission" "localhost:1527" "listen,resolve")

The configuration option in the `arquillian.xml` is `startDerby` = `true`/`false`