### PR TITLE
added openjdk8 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ matrix:
       env: CONTAINER=5.x
     - jdk: oraclejdk8
       env: CONTAINER=payara-4
+    - jdk: openjdk8
+      env: CONTAINER=4.x
+    - jdk: openjdk8
+      env: CONTAINER=5.x
+    - jdk: openjdk8
+      env: CONTAINER=payara-4
 
 cache:
   directories:


### PR DESCRIPTION
#### Short description of what this resolves:
Test might fail with OpenJDK while they pass with Oracle JDK.

#### Changes proposed in this pull request:

- Testing everything with OpenJDK8 that is tested with Oracle JDK 8 on Travis CI

